### PR TITLE
Fixed undefined behaviour

### DIFF
--- a/src/giac/first.h
+++ b/src/giac/first.h
@@ -80,7 +80,9 @@ inline Bidon operator << (Bidon,const char *){return Bidon();}
 #define COUT Bidon(0) //std::cout
 #define CERR Bidon(0) //std::cout
 typedef unsigned pid_t;
+#ifndef TICE
 double lgamma(double);
+#endif
 #else // FXCG
 
 #ifdef NSPIRE

--- a/ustl/cmath
+++ b/ustl/cmath
@@ -1,3 +1,7 @@
+#ifdef TICE
+#include_next <cmath>
+#else
 namespace std {
 #include <math.h>
 }
+#endif


### PR DESCRIPTION
```c++
// <cmath>
#ifdef _EZ80
#include_next <cmath>
#else
namespace std {
#include <math.h>
}
#endif
// <first.h>
#ifndef _EZ80
double lgamma(double);
#endif
```
All C++11 math functions and a few others should be under the global and std:: namespace on the CE C/C++ toolchain. `lgamma` is a reserved name under the global and std:: namespace https://eel.is/c++draft/reserved.names#extern.names-3