### PR TITLE
changed `my_isnan` and `my_isinf` to `isnan` and `isinf`

### DIFF
--- a/src/giac/global.h
+++ b/src/giac/global.h
@@ -968,8 +968,13 @@ throw(std::runtime_error("Stopped by user interruption.")); \
   std::string & xcasroot();
   std::string add_extension(const std::string & s,const std::string & ext,const std::string & def);
   std::string remove_filename(const std::string & s);
+#ifdef TICE
+  #define my_isnan(d) isnan(d)
+  #define my_isinf(d) isinf(d)
+#else
   bool my_isnan(double d);
   bool my_isinf(double d);
+#endif
 
   /* launch a new thread for evaluation only,
      no more readqueue, readqueue is done by the "parent" thread

--- a/src/giac/kglobal.cc
+++ b/src/giac/kglobal.cc
@@ -2276,12 +2276,14 @@ extern "C" void Sleep(unsigned int miliSecond);
 #endif
   }
 
+#ifndef TICE
   bool my_isinf(double d){
     return 1/d==0.0;
   }
   bool my_isnan(double d){
     return d!=0 && d==d*2 && !my_isinf(d);
   }
+#endif
 
 #if 0
   double giac_floor(double d){


### PR DESCRIPTION
`isnan` and `isinf` are fast assembly routines on the Ti84CE.
Also, NaN == NaN will always be false under IEEE 754 arithmetic. So the following code will always return false. `d != d` should return true when `d` is NaN
```c++
  bool my_isnan(double d){
    return d!=0 && d==d*2 && !my_isinf(d);
  }
```