### PR TITLE
fixed app_tools/makefile for windows

### DIFF
--- a/app_tools/makefile
+++ b/app_tools/makefile
@@ -18,12 +18,17 @@ default: app # install_prog
 include $(shell cedev-config --makefile)
 
 TARGET8EK ?= $(NAME).8ek
+TARGETBIN ?= $(NAME).bin
 APP_INST_NAME ?= APPINST
 APP_INST_DESC ?= App Installer
 APP_INST_VAR_PREFIX ?= AppIns
 
 app: $(BINDIR)/$(TARGET8EK)
 # install_prog: $(BINDIR)/AppIns0.8xv $(BINDIR)/INSTALL.8xp
+
+$(BINDIR)/$(TARGETBIN): $(BINDIR)/$(TARGETOBJ) $(MAKEFILE_LIST) $(DEPS)
+	$(Q)$(call MKDIR,$(@D))
+	$(Q)(OBJCOPY) -O binary $(call QUOTE_ARG,$<) $(call QUOTE_ARG,$@)
 
 $(BINDIR)/$(TARGET8EK): $(BINDIR)/$(TARGETBIN) $(APP_TOOLS_DIR)/make_8ek.py
 	python3 $(APP_TOOLS_DIR)/make_8ek.py $(BINDIR)/$(TARGETBIN) $(BINDIR)/$(TARGET8EK) $(NAME)
@@ -40,4 +45,4 @@ $(BINDIR)/INSTALL.8xp:
 	VAR_PREFIX="$(APP_INST_VAR_PREFIX)" \
 	$(MAKE) -C $(APP_TOOLS_DIR)/installer
 
-.PHONY: default app # install_prog 
+.PHONY: default app # install_prog


### PR DESCRIPTION
When compiling with MSYS2 UCRT64 on Windows 11 I get this error:
```
zerico@DESKTOP-7OMIH9B MINGW64 ~/Programming/ez80/ti-ce
$ make clean
Removed built binaries and objects.

zerico@DESKTOP-7OMIH9B MINGW64 ~/Programming/ez80/ti-ce
$ make
make: *** No rule to make target `bin', needed by `bin/DEMO.8ek'.  Stop.
```

I am not sure how this impacts building on Linux or MacOS